### PR TITLE
use test-unit gem instead of Ruby 1.9.3 version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'tinder', '~> 1.4'
 
 group :building do
   gem 'rake'
+  gem 'test-unit'
 end
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -34,6 +34,7 @@ GEM
     sinatra (1.2.6)
       rack (~> 1.1)
       tilt (>= 1.2.2, < 2.0)
+    test-unit (2.4.7)
     tilt (1.3.2)
     tinder (1.7.0)
       activesupport (< 4, >= 2.3)
@@ -69,6 +70,7 @@ DEPENDENCIES
   pg
   rake
   sinatra
+  test-unit
   tinder (~> 1.4)
   unicorn
   yajl-ruby


### PR DESCRIPTION
1.9.3-p125 says "file not found" on `rake test`, probably related to this: https://github.com/jimweirich/rake/issues/51

Solutions: use test-unit gem, as it doesn't have the history of problems of test/unit bundled with Ruby.
