### PR TITLE
Remove code refactored to source_names

### DIFF
--- a/services/victorops.rb
+++ b/services/victorops.rb
@@ -9,7 +9,6 @@ class Service::Victorops < Service
       settings[:routing_key].to_s.empty?
 
     events = payload[:events]
-    hosts = events.collect { |e| e[:source_name] }.sort.uniq
     entity_id = payload[:saved_search][:name]
     entity_display_name = source_names(events, 5)
     state_message = "#{entity_id} (#{entity_display_name})"


### PR DESCRIPTION
This removes a leftover line that doesn't do anything anymore