### PR TITLE
Use released version of metriks-librato_metrics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'net-http-persistent'
 gem 'scrolls'
 
 gem 'metriks'
-gem 'metriks-librato_metrics', :git => 'https://github.com/eric/metriks-librato_metrics.git'
+gem 'metriks-librato_metrics'
 
 gem 'hoptoad_notifier'
 gem "sentry-raven"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,3 @@
-GIT
-  remote: https://github.com/eric/metriks-librato_metrics.git
-  revision: 0e46e7c5f4eff47c199023a184f3d8ef52da12d0
-  specs:
-    metriks-librato_metrics (0.0)
-      metriks (>= 0.9.9.6)
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -64,6 +57,8 @@ GEM
       atomic (~> 1.0)
       avl_tree (~> 1.1.2)
       hitimes (~> 1.1)
+    metriks-librato_metrics (1.0.5)
+      metriks (>= 0.9.9.6)
     mime-types (1.19)
     mini_portile (0.6.0)
     mocha (0.13.1)
@@ -141,7 +136,7 @@ DEPENDENCIES
   librato-metrics (~> 1.0.1)
   mail (~> 2.2)
   metriks
-  metriks-librato_metrics!
+  metriks-librato_metrics
   mocha
   net-http-persistent
   pg


### PR DESCRIPTION
This was causing Travis builds to fail. I'm not sure the cause, but in looking into it, I noticed `master` was pointing to the latest gem release. Might as well switch to it.