### PR TITLE
Add cap of 20 metrics/request and remove req length constraints

### DIFF
--- a/services/cloud_watch.rb
+++ b/services/cloud_watch.rb
@@ -23,15 +23,12 @@ class Service::CloudWatch < Service
       metric_namespace = 'Papertrail'
     end
 
-    requests = []
-    metric_data.each_slice(metrics_per_request) do |metric_data_slice|
+    metric_data.each_slice(metrics_per_request).map do |metric_data_slice|
       requests << {
         namespace: metric_namespace,
         metric_data: metric_data_slice
       }
     end
-
-    requests
   end
 
   def receive_logs

--- a/services/cloud_watch.rb
+++ b/services/cloud_watch.rb
@@ -24,7 +24,7 @@ class Service::CloudWatch < Service
     end
 
     metric_data.each_slice(metrics_per_request).map do |metric_data_slice|
-      requests << {
+      {
         namespace: metric_namespace,
         metric_data: metric_data_slice
       }

--- a/services/cloud_watch.rb
+++ b/services/cloud_watch.rb
@@ -28,7 +28,7 @@ class Service::CloudWatch < Service
       requests << {
         namespace: metric_namespace,
         metric_data: metric_data_slice
-      }.to_json
+      }
     end
 
     requests

--- a/test/cloud_watch_test.rb
+++ b/test/cloud_watch_test.rb
@@ -20,12 +20,6 @@ class CloudWatchTest < PapertrailServices::TestCase
                    new_payload)
   end
 
-  def test_size
-    assert_raises(PapertrailServices::Service::ConfigurationError) {
-      @svc.prepare_post_data(@svc.payload[:events], size_limit=8)
-    }
-  end
-
   def test_counts
     counts = @svc.event_counts_by_received_at(payload[:events])
     # Static value for counts based on current sample payload; will fail if payload is changed


### PR DESCRIPTION
Enforce the  http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/cloudwatch_limits.html limit that this class is actually going to run into (20 metrics/requests). Remove the one (request length) which, because of that limit, it will not encounter.