### PR TITLE
slack: Provide a plain-text fallback for the attachment

### DIFF
--- a/test/slack_test.rb
+++ b/test/slack_test.rb
@@ -24,14 +24,14 @@ class SlackTest < PapertrailServices::TestCase
     svc.receive_logs
   end
 
-  def test_format_content_with_truncation
+  def test_build_attachments
     long_payload = payload.dup
     long_payload[:events] *= 100
 
     slack = Service::Slack.new
-    message = slack.format_content(long_payload[:events])
-
-    assert message.length < 8000
+    attachment = slack.build_attachments(long_payload[:events])
+    assert attachment[0][:text].length < 8000
+    assert attachment[0][:fallback].length < 8000
   end
 
   def service(*args)


### PR DESCRIPTION
From the Slack API documentation:

> A plain-text summary of the attachment. This text will be used in clients that don't show formatted text (eg. IRC, mobile notifications) and should not contain any markup.

<https://api.slack.com/docs/attachments>

Without the fallback, this is what IRC clients connected to the Slack/IRC gateway see:

<img width="768" alt="screenshot 2016-02-20 00 46 55" src="https://cloud.githubusercontent.com/assets/90/13192393/a26e966a-d76b-11e5-9750-2a73b38343a7.png">