### PR TITLE
Send search URI when reporting metric to Librato

### DIFF
--- a/services/libratometrics.rb
+++ b/services/libratometrics.rb
@@ -74,7 +74,10 @@ class Service::LibratoMetrics < Service
           :source       => source_name,
           :value        => count,
           :measure_time => time,
-          :type         => 'gauge'
+          :type         => 'gauge',
+          :attributes   => {
+            :backlink => payload[:saved_search][:html_search_url]
+          }
         }
       end
     end


### PR DESCRIPTION
When reporting metrics to Librato, include the search URI as an attribute. This will allow us to link back to searches where appropriate to give people an easier transition back to logs.

/cc @snorecone @lucky @mheffner