### PR TITLE
Hopefully make slack not truncate messages

### DIFF
--- a/services/slack.rb
+++ b/services/slack.rb
@@ -42,8 +42,8 @@ class Service::Slack < Service
     "```" + body + "```"
   end
 
-  # Slack truncates attachments at 8000 bytes
-  def build_body(events, limit = 7500)
+  # Slack truncates attachments at 7000 bytes
+  def build_body(events, limit = 7000)
     body = ''
 
     events.each do |event|


### PR DESCRIPTION
We keep running into issues where Slack truncates the messages and messes up the formatting. Hopefully reducing another 500 characters will give more room to do the right thing.