### PR TITLE
Allow stathat to receive counts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ tmp
 config/local.env
 vendor/bundle
 *~
+log/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -153,5 +153,8 @@ DEPENDENCIES
   unicorn
   yajl-ruby
 
+RUBY VERSION
+   ruby 1.9.3p545
+
 BUNDLED WITH
    1.13.1

--- a/test/stathat_test.rb
+++ b/test/stathat_test.rb
@@ -2,14 +2,14 @@ require File.expand_path('../helper', __FILE__)
 
 class StathatTest < PapertrailServices::TestCase
   def test_config
-    svc = service(:logs, {}.with_indifferent_access, payload)
-    assert_raises(PapertrailServices::Service::ConfigurationError) { svc.receive_logs }
+    svc = service(:logs, {}.with_indifferent_access, counts_payload)
+    assert_raises(PapertrailServices::Service::ConfigurationError) { svc.receive_counts }
 
-    svc = service(:logs, {"ezkey" => "foobar"}.with_indifferent_access, payload)
-    assert_raises(PapertrailServices::Service::ConfigurationError) { svc.receive_logs }
+    svc = service(:logs, {"ezkey" => "foobar"}.with_indifferent_access, counts_payload)
+    assert_raises(PapertrailServices::Service::ConfigurationError) { svc.receive_counts }
 
-    svc = service(:logs, {"stat" => "foobar"}.with_indifferent_access, payload)
-    assert_raises(PapertrailServices::Service::ConfigurationError) { svc.receive_logs }
+    svc = service(:logs, {"stat" => "foobar"}.with_indifferent_access, counts_payload)
+    assert_raises(PapertrailServices::Service::ConfigurationError) { svc.receive_counts }
   end
 
   def test_logs
@@ -20,6 +20,29 @@ class StathatTest < PapertrailServices::TestCase
     end
 
     svc.receive_logs
+  end
+
+  def test_counts
+    svc = service(:counts, {"ezkey" => "foo@bar.com", "stat" => "foo.bar"}.with_indifferent_access, counts_payload)
+
+    http_stubs.post "/ez" do |env|
+      [200, {}, ""]
+    end
+
+    svc.receive_counts
+  end
+
+  def test_counts_payload_to_metrics
+    svc = service(:counts, {"ezkey" => "foo@bar.com", "stat" => "foo.bar"}.with_indifferent_access, counts_payload)
+    expected = [
+      { stat: "foo.bar", count: 1, t: 1311369001 },
+      { stat: "foo.bar", count: 1, t: 1311369010 },
+      { stat: "foo.bar", count: 1, t: 1311370201 },
+      { stat: "foo.bar", count: 1, t: 1311370801 },
+      { stat: "foo.bar", count: 1, t: 1311371401 }
+    ]
+
+    assert_equal expected, svc.counts_payload_to_metrics
   end
 
   def service(*args)


### PR DESCRIPTION
Since stathat is a metrics service, receiving counts instead of logs would make more sense and should use less resources.