### PR TITLE
Take into account existing query string when adding additional query params to urls

### DIFF
--- a/lib/papertrail_services/helpers/logs_helpers.rb
+++ b/lib/papertrail_services/helpers/logs_helpers.rb
@@ -57,6 +57,29 @@ module PapertrailServices
         "#{time.strftime('%b %d %X')} #{message[:source_name]} #{message[:program]}: #{message[:message]}"
       end
 
+      def html_syslog_format(message, html_search_url)
+        received_at = Time.zone.at(Time.iso8601(message[:received_at]))
+        s = ''
+
+        if html_search_url
+          url = add_query_params(html_search_url, centered_on_id: message[:id])
+          s << "<a href=\"#{url}\" style=\"color:#444;\">#{received_at.strftime('%b %d %X')}</a>"
+        else
+          s << received_at.strftime('%b %d %X')
+        end
+
+        s << " #{h(message[:source_name])} #{h(message[:program])}: #{h(message[:message])}"
+      end
+
+      def add_query_params(url, params)
+        url = URI.parse(url)
+
+        query = Rack::Utils.parse_query(url.query).with_indifferent_access.merge(params)
+
+        url.query = query.to_query
+        url.to_s
+      end
+
       def source_names(events, count)
         hosts = events.collect { |e| e[:source_name] }.sort.uniq
         if hosts.length < count

--- a/services/mail.rb
+++ b/services/mail.rb
@@ -40,20 +40,6 @@ class Service::Mail < Service
     end
   end
 
-  def html_syslog_format(message, html_search_url)
-    received_at = Time.zone.at(Time.iso8601(message[:received_at]))
-    s = ''
-
-    if html_search_url
-      url = html_search_url + '?' + { :centered_on_id => message[:id] }.to_query
-      s << "<a href=\"#{url}\" style=\"color:#444;\">#{received_at.strftime('%b %d %X')}</a>"
-    else
-      s << received_at.strftime('%b %d %X')
-    end
-
-    s << " #{h(message[:source_name])} #{h(message[:program])}: #{h(message[:message])}"
-  end
-
   def alert_time
     Time.zone.now.strftime('%F %R')
   end

--- a/test/mail_test.rb
+++ b/test/mail_test.rb
@@ -21,6 +21,18 @@ class MailTest < PapertrailServices::TestCase
     assert_not_nil message
   end
 
+  def test_html_syslog_format
+    svc = service(:logs, { :addresses => 'eric@papertrail.com' }, payload)
+
+    url = "https://papertrailapp.com/groups/999/events?q=searchstring&q_id=99999999"
+    syslog_format = svc.html_syslog_format(payload[:events].first, url)
+
+    assert_match '<a href="https://papertrailapp.com/groups/999/events?', syslog_format
+    assert_match 'centered_on_id=31171139124469760', syslog_format
+    assert_match 'q=searchstring', syslog_format
+    assert_match 'q_id=99999999', syslog_format
+  end
+
   def test_mail_message_multiple_recipients
     svc = service(:logs, { :addresses => 'eric@papertrail.com,troy@papertrail.com;larry@papertrail.com' }, payload)
 


### PR DESCRIPTION
Fixes #90

I also moved the `html_syslog_format` method into the helper module so that other services could use it if they so wish.