### PR TITLE
do not require spaces between datadog tags

### DIFF
--- a/services/datadog.rb
+++ b/services/datadog.rb
@@ -5,7 +5,7 @@ class Service::Datadog < Service
     raise_config_error 'Missing metric name' if settings[:metric].to_s.empty?
 
     unless settings[:tags].to_s.empty?
-      tags = settings[:tags].to_s.split(/,\s*/)
+      tags = settings[:tags].to_s.split(/\s*,\s*/)
     end
 
     # values[hostname][time]

--- a/services/datadog.rb
+++ b/services/datadog.rb
@@ -5,7 +5,7 @@ class Service::Datadog < Service
     raise_config_error 'Missing metric name' if settings[:metric].to_s.empty?
 
     unless settings[:tags].to_s.empty?
-      tags = settings[:tags].to_s.split(/,\s+/)
+      tags = settings[:tags].to_s.split(/,\s*/)
     end
 
     # values[hostname][time]

--- a/test/datadog_test.rb
+++ b/test/datadog_test.rb
@@ -13,9 +13,39 @@ class DatadogTest < PapertrailServices::TestCase
   end
 
   def test_logs
-    svc = service(:logs, { 'api_key' => 'foobar', "metric" => "foo.bar"}.with_indifferent_access, payload)
+    svc = service(:logs, { 'api_key' => 'foobar', "metric" => "foo.bar" }.with_indifferent_access, payload)
 
     http_stubs.post "/api/v1/series" do |env|
+      body = JSON(env[:body])
+
+      [200, {}, ""]
+    end
+
+    svc.receive_logs
+  end
+
+  def test_tagged_logs
+    svc = service(:logs, { 'api_key' => 'foobar', "metric" => "foo.bar", 'tags' => 'environment:production,sender:papertrail' }.with_indifferent_access, payload)
+
+    http_stubs.post "/api/v1/series" do |env|
+      body = JSON(env[:body])
+
+      assert body['series'][0]['tags'][0] == 'environment:production'
+
+      [200, {}, ""]
+    end
+
+    svc.receive_logs
+  end
+
+  def test_space_tagged_logs
+    svc = service(:logs, { 'api_key' => 'foobar', "metric" => "foo.bar", 'tags' => 'environment:staging, sender:papertrail' }.with_indifferent_access, payload)
+
+    http_stubs.post "/api/v1/series" do |env|
+      body = JSON(env[:body])
+
+      assert body['series'][0]['tags'][0] == 'environment:staging'
+
       [200, {}, ""]
     end
 

--- a/test/datadog_test.rb
+++ b/test/datadog_test.rb
@@ -24,14 +24,15 @@ class DatadogTest < PapertrailServices::TestCase
   end
 
   def test_tagged_logs
-    svc = service(:logs, { 'api_key' => 'foobar', "metric" => "foo.bar", 'tags' => 'environment:production,sender:papertrail, type:error' }.with_indifferent_access, payload)
+    svc = service(:logs, { 'api_key' => 'foobar', "metric" => "foo.bar", 'tags' => 'environment:production,sender:papertrail, severity:error ,type:NoMethodError' }.with_indifferent_access, payload)
 
     http_stubs.post "/api/v1/series" do |env|
       body = JSON(env[:body])
 
       assert body['series'][0]['tags'][0] == 'environment:production'
       assert body['series'][0]['tags'][1] == 'sender:papertrail'
-      assert body['series'][0]['tags'][2] == 'type:error'
+      assert body['series'][0]['tags'][2] == 'severity:error'
+      assert body['series'][0]['tags'][3] == 'type:NoMethodError'
 
       [200, {}, ""]
     end

--- a/test/datadog_test.rb
+++ b/test/datadog_test.rb
@@ -16,7 +16,6 @@ class DatadogTest < PapertrailServices::TestCase
     svc = service(:logs, { 'api_key' => 'foobar', "metric" => "foo.bar" }.with_indifferent_access, payload)
 
     http_stubs.post "/api/v1/series" do |env|
-      body = JSON(env[:body])
 
       [200, {}, ""]
     end
@@ -25,26 +24,14 @@ class DatadogTest < PapertrailServices::TestCase
   end
 
   def test_tagged_logs
-    svc = service(:logs, { 'api_key' => 'foobar', "metric" => "foo.bar", 'tags' => 'environment:production,sender:papertrail' }.with_indifferent_access, payload)
+    svc = service(:logs, { 'api_key' => 'foobar', "metric" => "foo.bar", 'tags' => 'environment:production,sender:papertrail, type:error' }.with_indifferent_access, payload)
 
     http_stubs.post "/api/v1/series" do |env|
       body = JSON(env[:body])
 
       assert body['series'][0]['tags'][0] == 'environment:production'
-
-      [200, {}, ""]
-    end
-
-    svc.receive_logs
-  end
-
-  def test_space_tagged_logs
-    svc = service(:logs, { 'api_key' => 'foobar', "metric" => "foo.bar", 'tags' => 'environment:staging, sender:papertrail' }.with_indifferent_access, payload)
-
-    http_stubs.post "/api/v1/series" do |env|
-      body = JSON(env[:body])
-
-      assert body['series'][0]['tags'][0] == 'environment:staging'
+      assert body['series'][0]['tags'][1] == 'sender:papertrail'
+      assert body['series'][0]['tags'][2] == 'type:error'
 
       [200, {}, ""]
     end


### PR DESCRIPTION
Our example doesn't have a space, and requiring them seems unnecessary. How I see this possible change's impact:

**Pros**
* Be consistent with our example, which doesn't use spaces.
* Ignore things that should be irrelevant in this context (customers shouldn't have to care how they format their separators if we know how to do it correctly).

**Cons**
* The ~70 existing alerts that have no or inconsistent spaces in their tags will most likely see a change in behavior. Currently, if the bug report reflects the behavior correctly, these tags are not separated, but instead the `,` is converted to `_`, making one long tag. This PR would make these separate labels. It's possible that customers are currently depending on the existing labels and changing them could affect their DataDog monitoring or alerting.

How I see the possibilities for going forward:

**Options**
* Proceed with this PR and assume the new behavior will be better.
* Proceed with this PR and preserve existing behavior, but allow correct behavior for new alerts, by changing the way the current tag values are entered (convert `,` to `_`).
* Don't proceed with this PR, and clearly document and show by example that the correct separator is `,` followed by ` `.
* Contact those with these alerts before proceeding with this PR to give them the opportunity to choose. 
* There's always not doing anything, but that doesn't seem as good as the documentation option.