### PR TITLE
make ID a string since it is not an arithmetical number

### DIFF
--- a/services/newrelic.rb
+++ b/services/newrelic.rb
@@ -32,6 +32,7 @@ class Service::NewRelic < Service
 
     event[:timestamp] = event[:received_at] = Time.iso8601(event[:received_at]).to_i
     event[:message] = event[:message].truncate(4000, :separator => ' ')
+    event[:id] = event[:id].to_s
 
     event
   end

--- a/test/newrelic_test.rb
+++ b/test/newrelic_test.rb
@@ -63,6 +63,7 @@ class NewRelicTest < PapertrailServices::TestCase
       assert(body[0]['search_name'] == 'cron', "Did not find expected search name key")
       assert(body[0]['message'].bytesize < 4000, "Included a message that is too long")
       assert(body[0]['received_at'].to_i == body[0]['received_at'], "received_at is not a number")
+      assert(body[0]['id'].to_s == body[0]['id'], "id is not a string")
 
       [200, {}, ""]
       


### PR DESCRIPTION
In Insights, anything that isn't a number you can do math to should be a string :)