### PR TITLE
Adding a hostedgraphite integration to papertrail.

### DIFF
--- a/services/hostedgraphite.rb
+++ b/services/hostedgraphite.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 class Service::HostedGraphite < Service
-  def receive_logs
+  def receive_counts
     raise_config_error 'Missing API Key' if settings[:api_key].to_s.empty?
     raise_config_error 'Missing metric name' if settings[:metric].to_s.empty?
 

--- a/services/hostedgraphite.rb
+++ b/services/hostedgraphite.rb
@@ -3,9 +3,8 @@ class Service::HostedGraphite < Service
   def receive_logs
     raise_config_error 'Missing API Key' if settings[:api_key].to_s.empty?
     raise_config_error 'Missing metric name' if settings[:metric].to_s.empty?
-    raise_config_error 'Missing HostedGraphite Endpoint' if settings[:hostedgraphite_endpoint].to_s.empty?
-    
-    metric_url = settings[:hostedgraphite_endpoint].to_s
+
+    metric_url = 'https://api.hostedgraphite.com/api/v1/sink'
     base_metric = settings[:metric]
     search = payload[:saved_search]
     data_to_send = Array.new
@@ -13,13 +12,13 @@ class Service::HostedGraphite < Service
       payload[:counts].each do |metric|
         src = metric[:source_name].gsub(/\s+/, "")
         full_metric = base_metric + '.' + src
-        metric[:timeseries].each do |timestamp, val|        
+        metric[:timeseries].each do |timestamp, val|
           mstring = [full_metric, val, timestamp, "\n"].join(" ")
           data_to_send.push(mstring)
-        end      
+        end
       end
     end
-    
+
     http.basic_auth settings[:api_key], ""
     http.headers['content-type'] = 'application/json'
     data_to_send.each do |metric|

--- a/services/hostedgraphite.rb
+++ b/services/hostedgraphite.rb
@@ -4,7 +4,7 @@ class Service::HostedGraphite < Service
     raise_config_error 'Missing API Key' if settings[:api_key].to_s.empty?
     raise_config_error 'Missing metric name' if settings[:metric].to_s.empty?
 
-    metric_url = 'https://api.hostedgraphite.com/api/v1/sink'
+    metric_url = 'https://www.hostedgraphite.com/api/v1/sink'
     base_metric = settings[:metric]
     search = payload[:saved_search]
     data_to_send = Array.new

--- a/services/hostedgraphite.rb
+++ b/services/hostedgraphite.rb
@@ -1,0 +1,36 @@
+# encoding: utf-8
+class Service::HostedGraphite < Service
+  def receive_logs
+    raise_config_error 'Missing API Key' if settings[:api_key].to_s.empty?
+    raise_config_error 'Missing metric name' if settings[:metric].to_s.empty?
+    raise_config_error 'Missing HostedGraphite Endpoint' if settings[:hostedgraphite_endpoint].to_s.empty?
+    
+    metric_url = settings[:hostedgraphite_endpoint].to_s
+    base_metric = settings[:metric]
+    search = payload[:saved_search]
+    data_to_send = Array.new
+    if payload.key?(:counts)
+      payload[:counts].each do |metric|
+        src = metric[:source_name].gsub(/\s+/, "")
+        full_metric = base_metric + '.' + src
+        metric[:timeseries].each do |timestamp, val|        
+          mstring = [full_metric, val, timestamp, "\n"].join(" ")
+          data_to_send.push(mstring)
+        end      
+      end
+    end
+    
+    http.basic_auth settings[:api_key], ""
+    http.headers['content-type'] = 'application/json'
+    data_to_send.each do |metric|
+      resp = http_post metric_url do |req|
+        req.body = metric
+      end
+
+      unless resp.success?
+        puts "hostedgraphite: #{payload[:saved_search][:id]}: #{resp.status}: #{resp.body}"
+        raise_config_error("Hosted Graphite metrics could not be sent")
+      end
+    end
+  end
+end

--- a/test/hostedgraphite_test.rb
+++ b/test/hostedgraphite_test.rb
@@ -11,13 +11,11 @@ class HostedGraphiteTest < PapertrailServices::TestCase
     serv = service(:logs, {"metric" => "foobar"}.with_indifferent_access,counts_payload)
     assert_raises(PapertrailServices::Service::ConfigurationError) { serv.receive_logs }
 
-    serv = service(:logs, {"hostedgraphite_endpoint" => "/api/v1/sink"}.with_indifferent_access,counts_payload)
-    assert_raises(PapertrailServices::Service::ConfigurationError) { serv.receive_logs }
   end
 
   def test_logs_valid
     serv = service(:logs, {"api_key" => "foo-bar-baz", "metric" => "nice.metric.name",
-                          "hostedgraphite_endpoint" => "/api/v1/sink"}.with_indifferent_access,
+                          }.with_indifferent_access,
                          counts_payload)
     http_stubs.post "/api/v1/sink" do |env|
         [200, {}, ""]
@@ -28,15 +26,15 @@ class HostedGraphiteTest < PapertrailServices::TestCase
 
   def test_payload_empty
     serv = service(:logs, {"api_key" => "foo-bar-baz", "metric" => "nice.metric.name",
-                          "hostedgraphite_endpoint" => "/api/v1/sink"}.with_indifferent_access,
+                          }.with_indifferent_access,
                           {})
-    
+
     serv.receive_logs
   end
 
   def test_invalid_payload
     serv = service(:logs, {"api_key" => "foo-bar-baz", "metric" => "nice.metric.name",
-                          "hostedgraphite_endpoint" => "/api/v1/sink"}.with_indifferent_access,
+                          }.with_indifferent_access,
                           payload)
     serv.receive_logs
   end

--- a/test/hostedgraphite_test.rb
+++ b/test/hostedgraphite_test.rb
@@ -1,0 +1,47 @@
+require File.expand_path('../helper', __FILE__)
+
+class HostedGraphiteTest < PapertrailServices::TestCase
+  def test_config
+    serv = service(:logs, {}.with_indifferent_access, counts_payload)
+    assert_raises(PapertrailServices::Service::ConfigurationError) { serv.receive_logs }
+
+    serv = service(:logs, {"api_key" => "foobar"}.with_indifferent_access,counts_payload)
+    assert_raises(PapertrailServices::Service::ConfigurationError) { serv.receive_logs }
+
+    serv = service(:logs, {"metric" => "foobar"}.with_indifferent_access,counts_payload)
+    assert_raises(PapertrailServices::Service::ConfigurationError) { serv.receive_logs }
+
+    serv = service(:logs, {"hostedgraphite_endpoint" => "/api/v1/sink"}.with_indifferent_access,counts_payload)
+    assert_raises(PapertrailServices::Service::ConfigurationError) { serv.receive_logs }
+  end
+
+  def test_logs_valid
+    serv = service(:logs, {"api_key" => "foo-bar-baz", "metric" => "nice.metric.name",
+                          "hostedgraphite_endpoint" => "/api/v1/sink"}.with_indifferent_access,
+                         counts_payload)
+    http_stubs.post "/api/v1/sink" do |env|
+        [200, {}, ""]
+    end
+
+    serv.receive_logs
+  end
+
+  def test_payload_empty
+    serv = service(:logs, {"api_key" => "foo-bar-baz", "metric" => "nice.metric.name",
+                          "hostedgraphite_endpoint" => "/api/v1/sink"}.with_indifferent_access,
+                          {})
+    
+    serv.receive_logs
+  end
+
+  def test_invalid_payload
+    serv = service(:logs, {"api_key" => "foo-bar-baz", "metric" => "nice.metric.name",
+                          "hostedgraphite_endpoint" => "/api/v1/sink"}.with_indifferent_access,
+                          payload)
+    serv.receive_logs
+  end
+
+  def service(*args)
+    super Service::HostedGraphite, *args
+  end
+end

--- a/test/hostedgraphite_test.rb
+++ b/test/hostedgraphite_test.rb
@@ -3,13 +3,13 @@ require File.expand_path('../helper', __FILE__)
 class HostedGraphiteTest < PapertrailServices::TestCase
   def test_config
     serv = service(:logs, {}.with_indifferent_access, counts_payload)
-    assert_raises(PapertrailServices::Service::ConfigurationError) { serv.receive_logs }
+    assert_raises(PapertrailServices::Service::ConfigurationError) { serv.receive_counts }
 
     serv = service(:logs, {"api_key" => "foobar"}.with_indifferent_access,counts_payload)
-    assert_raises(PapertrailServices::Service::ConfigurationError) { serv.receive_logs }
+    assert_raises(PapertrailServices::Service::ConfigurationError) { serv.receive_counts }
 
     serv = service(:logs, {"metric" => "foobar"}.with_indifferent_access,counts_payload)
-    assert_raises(PapertrailServices::Service::ConfigurationError) { serv.receive_logs }
+    assert_raises(PapertrailServices::Service::ConfigurationError) { serv.receive_counts }
 
   end
 
@@ -21,7 +21,7 @@ class HostedGraphiteTest < PapertrailServices::TestCase
         [200, {}, ""]
     end
 
-    serv.receive_logs
+    serv.receive_counts
   end
 
   def test_payload_empty
@@ -29,14 +29,14 @@ class HostedGraphiteTest < PapertrailServices::TestCase
                           }.with_indifferent_access,
                           {})
 
-    serv.receive_logs
+    serv.receive_counts
   end
 
   def test_invalid_payload
     serv = service(:logs, {"api_key" => "foo-bar-baz", "metric" => "nice.metric.name",
                           }.with_indifferent_access,
                           payload)
-    serv.receive_logs
+    serv.receive_counts
   end
 
   def service(*args)


### PR DESCRIPTION
This integration is for the [count-only webhooks ](http://help.papertrailapp.com/kb/how-it-works/web-hooks/#count-only-webhooks), this might be expanded to include all event webhooks in the future.

For the moment we will need 3 inputs from the user,
1. hostedgraphite api_key.
2. metric name
3. hostedgraphite endpoint (something like: ""https://www.hostedgraphite.com/api/v1/sink")

num1 and num2 can be found in a users account on hostedgraphite.com

Let me know what other information I need to provide, also I'm not a regular ruby coder so apologies if there's any stupid mistakes in here.