### PR TITLE
remove heroku gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,7 +38,6 @@ gem 'rushover'
 
 group :development do
   gem 'foreman'
-  gem 'heroku'
 end
 
 group :building do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ GEM
     activesupport (3.2.12)
       i18n (~> 0.6)
       multi_json (~> 1.0)
-    addressable (2.3.2)
     aggregate (0.2.2)
     atomic (1.1.16)
     avl_tree (1.1.3)
@@ -13,7 +12,6 @@ GEM
       nokogiri (>= 1.4.4)
     builder (3.1.4)
     eventmachine (1.0.0)
-    excon (0.16.10)
     faraday (0.8.8)
       multipart-post (~> 1.2.0)
     faraday_middleware (0.9.0)
@@ -21,14 +19,6 @@ GEM
     foreman (0.60.2)
       thor (>= 0.13.6)
     hashie (1.2.0)
-    heroku (2.33.5)
-      heroku-api (~> 0.3.7)
-      launchy (>= 0.3.2)
-      netrc (~> 0.7.7)
-      rest-client (~> 1.6.1)
-      rubyzip
-    heroku-api (0.3.7)
-      excon (~> 0.16.10)
     hipchat-api (1.0.5)
       httparty
     hitimes (1.2.1)
@@ -42,8 +32,6 @@ GEM
     i18n (0.6.1)
     json (1.7.5)
     kgio (2.8.0)
-    launchy (2.1.2)
-      addressable (~> 2.3)
     librato-metrics (1.0.3)
       aggregate (~> 0.2.2)
       faraday (~> 0.7)
@@ -67,7 +55,6 @@ GEM
     multi_xml (0.5.1)
     multipart-post (1.2.0)
     net-http-persistent (2.9.4)
-    netrc (0.7.7)
     newrelic_rpm (3.17.2.327)
     nokogiri (1.6.2.1)
       mini_portile (= 0.6.0)
@@ -82,7 +69,6 @@ GEM
     rake (10.0.3)
     rest-client (1.6.7)
       mime-types (>= 1.16)
-    rubyzip (0.9.9)
     rushover (0.3.0)
       json
       rest-client
@@ -131,7 +117,6 @@ DEPENDENCIES
   aws-sdk (~> 1.43.3)
   faraday
   foreman
-  heroku
   hipchat-api
   hoptoad_notifier
   librato-metrics (~> 1.0.1)


### PR DESCRIPTION
The Heroku gem is deprecated, and it doesn't seem to be serving any purpose here that I can find. It was added in [this commit to add Puma](https://github.com/papertrail/papertrail-services/commit/1ce578ae101392ac0362f9b01a4bcc780d492ca3) a long time ago.

I ran the tests, and they all passed - which doesn't mean it's safe, but it's a start :)

The advantage in removing it (besides just not having extra gems) is that installing Heroku as a gem messes up installs of the more recent Heroku toolbelt when rbenv is also in use.