### PR TITLE
use gauge type for Datadog metric

### DIFF
--- a/services/datadog.rb
+++ b/services/datadog.rb
@@ -28,7 +28,7 @@ class Service::Datadog < Service
         :points => points.to_a,
         :host => hostname,
         :tags => tags,
-        :type => 'counter'
+        :type => 'gauge'
       }
     end
 


### PR DESCRIPTION
`counter` is a deprecated type, and is also treated as a rate in the Datadog UI, per https://help.datadoghq.com/hc/en-us/articles/206955236-Metric-types-in-Datadog; Papertrail counts aren't rates.

The Datadog API prefers `gauge` type, and gauge metrics will display counts corresponding to those seen in Papertrail when visualized with the correct settings. 

Prior to production change it'll be determined whether this affects existing metrics in Datadog.