### PR TITLE
initial add of new address to mail body

### DIFF
--- a/services/mail.rb
+++ b/services/mail.rb
@@ -101,7 +101,7 @@ class Service::Mail < Service
             <p>
               <strong>Upcoming change</strong>
               <br />
-              Beginning September 12, this email will come from alert@papertrailapp.com. <a href="http://www.papertrailstatus.com/">read more</a>
+              Beginning September 12, this email will come from alert@papertrailapp.com. <a href="http://www.papertrailstatus.com/">Read more »</a>
             </p>
           </div>
             <div style="color:#444;font-size:12px;line-height:130%;border-top:1px solid #ddd;margin-top:35px;">

--- a/services/mail.rb
+++ b/services/mail.rb
@@ -101,7 +101,7 @@ class Service::Mail < Service
             <p>
               <strong>Upcoming change</strong>
               <br />
-              Beginning September 12, this email will come from alert@papertrailapp.com. <a href="http://www.papertrailstatus.com/">Read more »</a>
+              Beginning September 12, this email will come from alert@papertrailapp.com. <a href="http://www.papertrailstatus.com/incidents/7xfb65y1tkk5">Read more »</a>
             </p>
           </div>
             <div style="color:#444;font-size:12px;line-height:130%;border-top:1px solid #ddd;margin-top:35px;">
@@ -138,7 +138,7 @@ class Service::Mail < Service
 
       --
       Beginning September 12, this email will come from alert@papertrailapp.com. For more,
-      see http://www.papertrailstatus.com/.
+      see http://www.papertrailstatus.com/incidents/7xfb65y1tkk5.
 
       --
       Can we help?

--- a/services/mail.rb
+++ b/services/mail.rb
@@ -97,6 +97,13 @@ class Service::Mail < Service
             <li><a href="<%= payload[:saved_search][:html_edit_url] %>">Edit or unsubscribe</a></li>
           </ul>
 
+          <div style="color:#444;font-size:12px;line-height:130%;border-top:1px solid #ddd;margin-top:35px;">
+            <p>
+              <strong>Upcoming change</strong>
+              <br />
+              Beginning September 12, this email will come from alert@papertrailapp.com. <a href="http://www.papertrailstatus.com/">read more</a>
+            </p>
+          </div>
             <div style="color:#444;font-size:12px;line-height:130%;border-top:1px solid #ddd;margin-top:35px;">
               <p>
                 <strong>Can we help?</strong>
@@ -129,6 +136,9 @@ class Service::Mail < Service
 
       Edit or unsubscribe: <%= payload[:saved_search][:html_edit_url] %>
 
+      --
+      Beginning September 12, this email will come from alert@papertrailapp.com. For more,
+      see http://www.papertrailstatus.com/.
 
       --
       Can we help?


### PR DESCRIPTION
This is an extension of the previous header add to include the upcoming address change in the body, so that Gmail/Google Apps can work with it for filtering, with reference to the scheduled maintenance at http://www.papertrailstatus.com/incidents/7xfb65y1tkk5.