### PR TITLE
Fix PagerDuty inactivity alert

### DIFF
--- a/services/pagerduty.rb
+++ b/services/pagerduty.rb
@@ -70,7 +70,7 @@ class Service::Pagerduty < Service
     else
       frequency   = frequency_phrase(payload[:frequency])
       search_url  = payload[:saved_search][:html_search_url]
-      description = %{"#{settings[:description]} found 0 matches #{frequency}}
+      description = %{#{settings[:description]} found 0 matches #{frequency}}
 
       body = {
         :description => description,

--- a/services/pagerduty.rb
+++ b/services/pagerduty.rb
@@ -3,61 +3,87 @@
 # Initial implementation by Mike Heffner:
 #  https://github.com/librato/papertrail_pagerduty_webhook
 class Service::Pagerduty < Service
-  def receive_logs
+  def post_data(body)
     size_limit = 3.megabytes # PagerDuty specified 3mb as of Aug 2016
 
-    events_by_incident_key = Hash.new do |h,k|
-      h[k] = []
-    end
+    body[:service_key] = settings[:service_key].to_s.strip
+    body[:event_type] = 'trigger'
 
-    payload[:events].each do |event|
-      if settings[:incident_key].present?
-        incident_key = settings[:incident_key].gsub('%HOST%', event[:source_name])
-      end
-      events_by_incident_key[incident_key] << event
-    end
+    resp = http_post "https://events.pagerduty.com/generic/2010-04-15/create_event.json", json_limited(body, size_limit, body[:details][:messages])
+    unless resp.success?
+      error_body = Yajl::Parser.parse(resp.body) rescue nil
 
-    events_by_incident_key.each do |incident_key, events|
-      events.sort_by! { |e| e[:id].to_i }
-      hosts = events.collect { |e| e[:source_name] }.sort.uniq
-
-      if hosts.length < 5
-        description = "#{settings[:description]} (#{hosts.join(', ')})"
+      if error_body
+        raise_config_error("Unable to send: #{error_body['errors'].join(", ")}")
       else
-        description = "#{settings[:description]} (from #{hosts.length} hosts)"
+        puts "pagerduty: #{payload[:saved_search][:id]}: #{resp.status}: #{resp.body}"
       end
+    end
+  end
+
+  def receive_logs
+    events = payload[:events]
+
+    if events.present?
+      events_by_incident_key = Hash.new do |h,k|
+        h[k] = []
+      end
+
+      events.each do |event|
+        if settings[:incident_key].present?
+          incident_key = settings[:incident_key].gsub('%HOST%', event[:source_name])
+        end
+        events_by_incident_key[incident_key] << event
+      end
+
+      events_by_incident_key.each do |incident_key, events|
+        events.sort_by! { |e| e[:id].to_i }
+        hosts = events.collect { |e| e[:source_name] }.sort.uniq
+
+        if hosts.length < 5
+          description = "#{settings[:description]} (#{hosts.join(', ')})"
+        else
+          description = "#{settings[:description]} (from #{hosts.length} hosts)"
+        end
+
+        body = {
+          :description => description,
+          :details => {
+            :messages => events.collect { |event| syslog_format(event) }
+          }
+        }
+
+        if incident_key.present?
+          body[:incident_key] = incident_key
+        end
+
+        min_id, max_id = events.first[:id], events.last[:id]
+        base_url = payload[:saved_search][:html_search_url]
+
+        body[:details][:log_start_url] =
+          "#{base_url}?centered_on_id=#{payload[:min_id]}"
+        body[:details][:log_end_url] =
+          "#{base_url}?centered_on_id=#{payload[:max_id]}"
+
+        post_data(body)
+      end
+    else
+      frequency   = frequency_phrase(payload[:frequency])
+      search_url  = payload[:saved_search][:html_search_url]
+      description = %{"#{settings[:description]} found 0 matches #{frequency}}
 
       body = {
-        :service_key => settings[:service_key].to_s.strip,
-        :event_type => 'trigger',
         :description => description,
         :details => {
-          :messages => events.collect { |event| syslog_format(event) }
+          :search_url => search_url
         }
       }
 
-      if incident_key.present?
-        body[:incident_key] = incident_key
+      if settings[:incident_key].present?
+        body[:incident_key] = settings[:incident_key]
       end
 
-      min_id, max_id = events.first[:id], events.last[:id]
-      base_url = payload[:saved_search][:html_search_url]
-
-      body[:details][:log_start_url] =
-        "#{base_url}?centered_on_id=#{payload[:min_id]}"
-      body[:details][:log_end_url] =
-        "#{base_url}?centered_on_id=#{payload[:max_id]}"
-
-      resp = http_post "https://events.pagerduty.com/generic/2010-04-15/create_event.json", json_limited(body, size_limit, body[:details][:messages])
-      unless resp.success?
-        error_body = Yajl::Parser.parse(resp.body) rescue nil
-
-        if error_body
-          raise_config_error("Unable to send: #{error_body['errors'].join(", ")}")
-        else
-          puts "pagerduty: #{payload[:saved_search][:id]}: #{resp.status}: #{resp.body}"
-        end
-      end
+      post_data(body)
     end
   end
 end

--- a/test/pagerduty_test.rb
+++ b/test/pagerduty_test.rb
@@ -22,11 +22,18 @@ class PagerdutyTest < PapertrailServices::TestCase
   def test_logs
     svc = service(:logs, { :service_key => 'k' }, payload)
 
+    body = nil
     http_stubs.post '/generic/2010-04-15/create_event.json' do |env|
+      body = JSON(env[:body], symbolize_names: true)
       [200, {}, '']
     end
 
     svc.receive_logs
+
+    assert_not_nil body
+    assert_equal 5, body[:details][:messages].length
+    assert_equal 'https://papertrailapp.com/searches/392?centered_on_id=31171139124469760', body[:details][:log_start_url]
+    assert_equal 'https://papertrailapp.com/searches/392?centered_on_id=31181206313902080', body[:details][:log_end_url]
   end
 
   def test_no_logs
@@ -48,11 +55,16 @@ class PagerdutyTest < PapertrailServices::TestCase
   def test_logs_with_incident_key
     svc = service(:logs, { :service_key => 'k', :incident_key => '%HOST%/PAPERTRAIL' }, payload)
 
+    body = nil
     http_stubs.post '/generic/2010-04-15/create_event.json' do |env|
+      body = JSON(env[:body], symbolize_names: true)
       [200, {}, '']
     end
 
     svc.receive_logs
+
+    assert_not_nil body
+    assert_equal 'lullaby/PAPERTRAIL', body[:incident_key]
   end
 
 

--- a/test/pagerduty_test.rb
+++ b/test/pagerduty_test.rb
@@ -29,6 +29,22 @@ class PagerdutyTest < PapertrailServices::TestCase
     svc.receive_logs
   end
 
+  def test_no_logs
+    svc = service(:logs, { :description => 'PagerDuty test', :service_key => 'k' }, payload.dup.merge(:events => []))
+
+    body = nil
+    http_stubs.post '/generic/2010-04-15/create_event.json' do |env|
+      body = JSON(env[:body], symbolize_names: true)
+      [200, {}, '']
+    end
+
+    svc.receive_logs
+
+    assert_not_nil body
+    assert_equal 'PagerDuty test found 0 matches in the past minute', body[:description]
+    assert_equal 'https://papertrailapp.com/searches/392', body[:details][:search_url]
+  end
+
   def test_logs_with_incident_key
     svc = service(:logs, { :service_key => 'k', :incident_key => '%HOST%/PAPERTRAIL' }, payload)
 


### PR DESCRIPTION
This fixes an issue where inactivity alerts for PagerDuty were not working because that service was expecting a payload containing events.

Example in PagerDuty:
<img width="687" alt="screen shot 2017-08-01 at 3 45 33 pm" src="https://user-images.githubusercontent.com/1120851/28850271-88002914-76d0-11e7-8cd1-e98ecbe92dbe.png">

[Diff without whitespace changes](https://github.com/papertrail/papertrail-services/pull/107/files?w=1)

