### PR TITLE
Fix Pushover inactivity alert

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,9 +33,6 @@ gem 'librato-metrics', '~> 1.0.1', :require => "librato/metrics"
 # service :aws-sns
 gem 'aws-sdk', '~> 1.43.3'
 
-# service :pushover
-gem 'rushover'
-
 group :development do
   gem 'foreman'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -67,11 +67,6 @@ GEM
       rack
     raindrops (0.10.0)
     rake (10.0.3)
-    rest-client (1.6.7)
-      mime-types (>= 1.16)
-    rushover (0.3.0)
-      json
-      rest-client
     scrolls (0.3.8)
     sentry-raven (0.6.0)
       faraday (>= 0.7.6)
@@ -129,7 +124,6 @@ DEPENDENCIES
   pg
   puma
   rake
-  rushover
   scrolls
   sentry-raven
   sinatra
@@ -138,5 +132,8 @@ DEPENDENCIES
   unicorn
   yajl-ruby
 
+RUBY VERSION
+   ruby 1.9.3p545
+
 BUNDLED WITH
-   1.13.1
+   1.13.7

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,8 +132,5 @@ DEPENDENCIES
   unicorn
   yajl-ruby
 
-RUBY VERSION
-   ruby 1.9.3p545
-
 BUNDLED WITH
-   1.13.7
+   1.13.1

--- a/services/pushover.rb
+++ b/services/pushover.rb
@@ -43,9 +43,7 @@ class Service::Pushover < Service
     end
   end
 
-
   def pushover
     @pushover ||= Rushover::Client.new(settings[:token])
   end
-
 end

--- a/services/pushover.rb
+++ b/services/pushover.rb
@@ -19,6 +19,7 @@ class Service::Pushover < Service
       :url_title => "View logs on Papertrail"
     }
 
+    http.headers["content-type"] = "application/json"
     resp = http_post("https://api.pushover.net/1/messages.json", post_data.to_json)
 
     unless resp.success?

--- a/services/pushover.rb
+++ b/services/pushover.rb
@@ -10,7 +10,7 @@ class Service::Pushover < Service
       raise_config_error "Could not process payload"
     end
 
-    post_data = {
+    data = {
       :token => settings[:token],
       :user => settings[:user_key],
       :title => body[:title],
@@ -19,9 +19,9 @@ class Service::Pushover < Service
       :url => payload[:saved_search][:html_search_url],
       :url_title => "View logs on Papertrail"
     }
-    post_data = URI.encode_www_form(post_data)
+    data = URI.encode_www_form(data)
 
-    resp = http_post("https://api.pushover.net/1/messages.json", post_data)
+    resp = http_post("https://api.pushover.net/1/messages.json", data)
 
     unless resp.success?
       puts "pushover: #{resp.to_s}"

--- a/services/pushover.rb
+++ b/services/pushover.rb
@@ -9,6 +9,8 @@ class Service::Pushover < Service
       raise_config_error "Could not process payload"
     end
 
+    message = message.join(', ') if message.is_a?(Array)
+
     post_data = {
       :token => settings[:token],
       :user => settings[:user_key],

--- a/services/pushover.rb
+++ b/services/pushover.rb
@@ -3,26 +3,8 @@
 class Service::Pushover < Service
   attr_writer :pushover
 
-  def receive_logs
-    raise_config_error 'Missing pushover app token' if
-      settings[:token].to_s.empty?
-    raise_config_error 'Missing pushover user token' if
-      settings[:user_key].to_s.empty?
-
-    events = payload[:events]
-
-    hosts = events.collect { |e| e[:source_name] }.sort.uniq
-    title = payload[:saved_search][:name]
-    if hosts.length < 5
-        title = "#{title} (#{hosts.join(', ')})"
-      else
-        title = "#{title} (from #{hosts.length} hosts)"
-    end
-
-    message = events.collect { |item|
-      syslog_format(item)
-    }
-
+  def post_data(body)
+    message = body[:message]
     message = message[0..1020] + "..." if message.length > 1024
 
     if message.empty?
@@ -31,15 +13,60 @@ class Service::Pushover < Service
 
     resp = pushover.notify(settings[:user_key],
                            message,
-                           {title: title,
-                            timestamp: Time.iso8601(events[0][:received_at]).to_i,
-                            url: payload[:saved_search][:html_search_url],
+                           {title: body[:title],
+                            timestamp: body[:timestamp].to_i,
+                            url: body[:search_url],
                             url_title: "View logs on Papertrail"})
 
     unless resp.ok?
       puts "pushover: #{resp.to_s}"
 
       raise_config_error "Failed to post to Pushover"
+    end
+  end
+
+  def receive_logs
+    raise_config_error 'Missing pushover app token' if
+      settings[:token].to_s.empty?
+    raise_config_error 'Missing pushover user token' if
+      settings[:user_key].to_s.empty?
+
+    events = payload[:events]
+    title  = payload[:saved_search][:name]
+
+    if events.present?
+      hosts = events.collect { |e| e[:source_name] }.sort.uniq
+
+      if hosts.length < 5
+        title = "#{title} (#{hosts.join(', ')})"
+      else
+        title = "#{title} (from #{hosts.length} hosts)"
+      end
+
+      message = events.collect { |item|
+        syslog_format(item)
+      }
+
+      body = {
+        :title => title,
+        :message => message,
+        :timestamp => Time.iso8601(events[0][:received_at]),
+        :search_url => payload[:saved_search][:html_search_url]
+      }
+
+      post_data(body)
+    else
+      frequency = frequency_phrase(payload[:frequency])
+      message   = %{0 matches found #{frequency}}
+
+      body = {
+        :title => title,
+        :message => message,
+        :timestamp => Time.now,
+        :search_url => payload[:saved_search][:html_search_url]
+      }
+
+      post_data(body)
     end
   end
 

--- a/services/pushover.rb
+++ b/services/pushover.rb
@@ -19,7 +19,7 @@ class Service::Pushover < Service
       :url_title => "View logs on Papertrail"
     }
 
-    resp = http_post("https://api.pushover.net/1/messages.json", post_data)
+    resp = http_post("https://api.pushover.net/1/messages.json", post_data.to_json)
 
     unless resp.success?
       puts "pushover: #{resp.to_s}"

--- a/services/pushover.rb
+++ b/services/pushover.rb
@@ -18,9 +18,9 @@ class Service::Pushover < Service
       :url => payload[:saved_search][:html_search_url],
       :url_title => "View logs on Papertrail"
     }
+    post_data = URI.encode_www_form(post_data)
 
-    http.headers["content-type"] = "application/json"
-    resp = http_post("https://api.pushover.net/1/messages.json", post_data.to_json)
+    resp = http_post("https://api.pushover.net/1/messages.json", post_data)
 
     unless resp.success?
       puts "pushover: #{resp.to_s}"

--- a/services/pushover.rb
+++ b/services/pushover.rb
@@ -43,9 +43,9 @@ class Service::Pushover < Service
       hosts = events.collect { |e| e[:source_name] }.sort.uniq
 
       if hosts.length < 5
-        title = "#{title} (#{hosts.join(', ')})"
+        title += " (#{hosts.join(', ')})"
       else
-        title = "#{title} (from #{hosts.length} hosts)"
+        title += " (from #{hosts.length} hosts)"
       end
 
       message = events.collect { |item|

--- a/services/pushover.rb
+++ b/services/pushover.rb
@@ -3,13 +3,12 @@
 class Service::Pushover < Service
   def post_data(body)
     message = body[:message]
+    message = message.join(', ') if message.is_a?(Array)
     message = message[0..1020] + "..." if message.length > 1024
 
     if message.empty?
       raise_config_error "Could not process payload"
     end
-
-    message = message.join(', ') if message.is_a?(Array)
 
     post_data = {
       :token => settings[:token],

--- a/services/pushover.rb
+++ b/services/pushover.rb
@@ -1,6 +1,8 @@
 # coding: utf-8
 
 class Service::Pushover < Service
+  API_URL = "https://api.pushover.net/1/messages.json"
+
   def post_data(body)
     message = body[:message]
     message = message.join(', ') if message.is_a?(Array)
@@ -21,7 +23,7 @@ class Service::Pushover < Service
     }
     data = URI.encode_www_form(data)
 
-    resp = http_post("https://api.pushover.net/1/messages.json", data)
+    resp = http_post(API_URL, data)
 
     unless resp.success?
       puts "pushover: #{resp.to_s}"

--- a/test/pushover_test.rb
+++ b/test/pushover_test.rb
@@ -21,6 +21,7 @@ class PushoverTest < PapertrailServices::TestCase
     svc.receive_logs
 
     assert_not_nil body
+    assert_match /Jul 22 14:10:01 alien CROND/, body['message'][0]
     assert_equal 'cron (alien, lullaby)', body['title'][0]
     assert_equal 'https://papertrailapp.com/searches/392', body['url'][0]
   end

--- a/test/pushover_test.rb
+++ b/test/pushover_test.rb
@@ -14,16 +14,15 @@ class PushoverTest < PapertrailServices::TestCase
 
     body = nil
     http_stubs.post '/1/messages.json' do |env|
-      body = JSON(env[:body], symbolize_names: true)
+      body = CGI.parse(env[:body])
       [200, {}, '']
     end
 
     svc.receive_logs
 
     assert_not_nil body
-    assert_equal 5, body[:message].length
-    assert_equal 'cron (alien, lullaby)', body[:title]
-    assert_equal 'https://papertrailapp.com/searches/392', body[:url]
+    assert_equal 'cron (alien, lullaby)', body['title'][0]
+    assert_equal 'https://papertrailapp.com/searches/392', body['url'][0]
   end
 
   def test_no_logs
@@ -31,16 +30,16 @@ class PushoverTest < PapertrailServices::TestCase
 
     body = nil
     http_stubs.post '/1/messages.json' do |env|
-      body = JSON(env[:body], symbolize_names: true)
+      body = CGI.parse(env[:body])
       [200, {}, '']
     end
 
     svc.receive_logs
 
     assert_not_nil body
-    assert_equal '0 matches found in the past minute', body[:message]
-    assert_equal 'cron', body[:title]
-    assert_equal 'https://papertrailapp.com/searches/392', body[:url]
+    assert_equal '0 matches found in the past minute', body['message'][0]
+    assert_equal 'cron', body['title'][0]
+    assert_equal 'https://papertrailapp.com/searches/392', body['url'][0]
   end
 
   def service(*args)

--- a/test/pushover_test.rb
+++ b/test/pushover_test.rb
@@ -1,7 +1,6 @@
 require File.expand_path('../helper', __FILE__)
 
 class PushoverTest < PapertrailServices::TestCase
-
   def test_config
     svc = service(:logs, {:token => 'a sample token'}, payload)
     assert_raises(PapertrailServices::Service::ConfigurationError) { svc.receive_logs }
@@ -9,7 +8,7 @@ class PushoverTest < PapertrailServices::TestCase
     svc = service(:logs, {:user_key => 'a different token'}, payload)
     assert_raises(PapertrailServices::Service::ConfigurationError) { svc.receive_logs }
   end
-  
+
   def test_logs
     svc = service(:logs, {:token => 'a sample token',
                           :user_key => 'a different token'},
@@ -20,13 +19,9 @@ class PushoverTest < PapertrailServices::TestCase
 
       svc.receive_logs
     end
-
-
-
   end
 
   def service(*args)
     super Service::Pushover, *args
   end
-  
 end


### PR DESCRIPTION
This fixes an issue where inactivity alerts for Pushover were not working because that service was expecting a payload containing events. Also removed Rushover gem so payloads are testable and to closer match how other services send requests.

Example Pushover inactivity alert:
![img_1191](https://user-images.githubusercontent.com/1120851/29146487-3ed98cd4-7d16-11e7-88c4-fd0c35baea5b.png)


