### PR TITLE
add back footer about recent change

### DIFF
--- a/services/mail.rb
+++ b/services/mail.rb
@@ -98,7 +98,7 @@ class Service::Mail < Service
 
           <div style="color:#444;font-size:12px;line-height:130%;border-top:1px solid #ddd;margin-top:35px;">
             <p>
-              <strong>Recent change</strong>
+              <strong>Recent change: new email address</strong>
               <br />
               Alert emails now come from alert@papertrailapp.com. <a href="http://www.papertrailstatus.com/incidents/7xfb65y1tkk5">Read more »</a>
             </p>

--- a/services/mail.rb
+++ b/services/mail.rb
@@ -96,6 +96,13 @@ class Service::Mail < Service
             <li><a href="<%= payload[:saved_search][:html_edit_url] %>">Edit or unsubscribe</a></li>
           </ul>
 
+          <div style="color:#444;font-size:12px;line-height:130%;border-top:1px solid #ddd;margin-top:35px;">
+            <p>
+              <strong>Recent change</strong>
+              <br />
+              Alert emails now come from alert@papertrailapp.com. <a href="http://www.papertrailstatus.com/incidents/7xfb65y1tkk5">Read more »</a>
+            </p>
+          </div>
             <div style="color:#444;font-size:12px;line-height:130%;border-top:1px solid #ddd;margin-top:35px;">
               <p>
                 <strong>Can we help?</strong>
@@ -128,6 +135,9 @@ class Service::Mail < Service
 
       Edit or unsubscribe: <%= payload[:saved_search][:html_edit_url] %>
 
+      --
+      Alert emails now come from alert@papertrailapp.com. For more,
+      see http://www.papertrailstatus.com/incidents/7xfb65y1tkk5.
 
       --
       Can we help?


### PR DESCRIPTION
This should look pretty much like the version at https://github.com/papertrail/papertrail-services/commit/b5b5bf02850011898fac2ed49f7a84f92c9fff24, but with updated wording so that people can figure out what changed from the email itself.