### PR TITLE
update tzinfo to latest 0.3 series

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'sinatra'
 gem 'activesupport', '~> 3.0', :require => 'active_support'
 gem 'yajl-ruby', :require => [ 'yajl', 'yajl/json_gem' ]
 gem 'faraday'
-gem 'tzinfo', '~> 0.3'
+gem 'tzinfo', '~> 0.3.53'
 gem 'net-http-persistent'
 
 gem 'scrolls'

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gem 'sinatra'
 gem 'activesupport', '~> 3.0', :require => 'active_support'
 gem 'yajl-ruby', :require => [ 'yajl', 'yajl/json_gem' ]
 gem 'faraday'
-gem 'tzinfo'
+gem 'tzinfo', '~> 0.3'
 gem 'net-http-persistent'
 
 gem 'scrolls'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,6 @@ GEM
       rack-protection (~> 1.2)
       tilt (~> 1.3, >= 1.3.3)
     thor (0.16.0)
-    thread_safe (0.3.6)
     tilt (1.3.3)
     tinder (1.9.1)
       eventmachine (>= 0.12.0, < 2)
@@ -97,8 +96,7 @@ GEM
       eventmachine (>= 0.12.8)
       http_parser.rb (~> 0.5.1)
       simple_oauth (~> 0.1.4)
-    tzinfo (1.2.3)
-      thread_safe (~> 0.1)
+    tzinfo (0.3.53)
     unicorn (4.6.2)
       kgio (~> 2.6)
       rack
@@ -130,7 +128,7 @@ DEPENDENCIES
   sentry-raven
   sinatra
   tinder (~> 1.4)
-  tzinfo
+  tzinfo (~> 0.3)
   unicorn
   yajl-ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -128,7 +128,7 @@ DEPENDENCIES
   sentry-raven
   sinatra
   tinder (~> 1.4)
-  tzinfo (~> 0.3)
+  tzinfo (~> 0.3.53)
   unicorn
   yajl-ruby
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,7 @@ GEM
       rack-protection (~> 1.2)
       tilt (~> 1.3, >= 1.3.3)
     thor (0.16.0)
+    thread_safe (0.3.6)
     tilt (1.3.3)
     tinder (1.9.1)
       eventmachine (>= 0.12.0, < 2)
@@ -96,7 +97,8 @@ GEM
       eventmachine (>= 0.12.8)
       http_parser.rb (~> 0.5.1)
       simple_oauth (~> 0.1.4)
-    tzinfo (0.3.36)
+    tzinfo (1.2.3)
+      thread_safe (~> 0.1)
     unicorn (4.6.2)
       kgio (~> 2.6)
       rack
@@ -133,4 +135,4 @@ DEPENDENCIES
   yajl-ruby
 
 BUNDLED WITH
-   1.13.1
+   1.14.6


### PR DESCRIPTION
Fixes Moscow tz (changed in 2014) and probably other things, without changing major releases.