### PR TITLE
Add notify AO metric

### DIFF
--- a/lib/papertrail_services/app.rb
+++ b/lib/papertrail_services/app.rb
@@ -86,6 +86,8 @@ module PapertrailServices
         ensure
           Scrolls::Log.context = {}
         end
+
+        $stdout.puts "count#heroku.pt-services-notify.count=1 tag#status=#{response.status} tag#integration=#{svc.hook_name} tag#presenter=#{params['event']}"
       end
 
       get '/' do


### PR DESCRIPTION
Adds some custom metrics in the form of Heroku logs. We'll use a custom drain to send these to AppOptics