### PR TITLE
Aws sdk v3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,7 +37,8 @@ gem 'appoptics-api-ruby', :git => 'https://github.com/appoptics/appoptics-api-ru
   :ref => '23fe88a', :require => "appoptics/metrics"
 
 # service :aws-sns
-gem 'aws-sdk', '~> 1.6'
+gem 'aws-sdk-sns', '~> 1'
+gem 'aws-sdk-cloudwatch', '~> 1'
 
 group :development do
   gem 'foreman'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,9 +18,21 @@ GEM
     aggregate (0.2.2)
     atomic (1.1.16)
     avl_tree (1.1.3)
-    aws-sdk (1.43.3)
-      json (~> 1.4)
-      nokogiri (>= 1.4.4)
+    aws-eventstream (1.1.0)
+    aws-partitions (1.402.0)
+    aws-sdk-cloudwatch (1.46.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
+      aws-sigv4 (~> 1.1)
+    aws-sdk-core (3.110.0)
+      aws-eventstream (~> 1, >= 1.0.2)
+      aws-partitions (~> 1, >= 1.239.0)
+      aws-sigv4 (~> 1.1)
+      jmespath (~> 1.0)
+    aws-sdk-sns (1.36.0)
+      aws-sdk-core (~> 3, >= 3.109.0)
+      aws-sigv4 (~> 1.1)
+    aws-sigv4 (1.2.2)
+      aws-eventstream (~> 1, >= 1.0.2)
     concurrent-ruby (1.1.5)
     eventmachine (1.2.7)
     faraday (0.8.8)
@@ -39,6 +51,7 @@ GEM
       multi_xml
     i18n (1.6.0)
       concurrent-ruby (~> 1.0)
+    jmespath (1.4.0)
     json (1.8.6)
     kgio (2.11.2)
     librato-metrics (1.0.3)
@@ -116,7 +129,8 @@ PLATFORMS
 DEPENDENCIES
   activesupport (~> 5.2.3)
   appoptics-api-ruby!
-  aws-sdk (~> 1.6)
+  aws-sdk-cloudwatch (~> 1)
+  aws-sdk-sns (~> 1)
   eventmachine (~> 1.2)
   foreman
   hipchat-api
@@ -143,4 +157,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/services/cloud_watch.rb
+++ b/services/cloud_watch.rb
@@ -1,5 +1,3 @@
-require 'aws-sdk'
-
 class Service::CloudWatch < Service
 
   def prepare_post_data(events, metrics_per_request = 20, max_days = 14)
@@ -42,17 +40,23 @@ class Service::CloudWatch < Service
         setting.to_s.empty?
     end
 
-    cloudwatch = AWS::CloudWatch::Client.new(
+    cloudwatch = Aws::CloudWatch::Client.new(
       region: settings[:aws_region],
-      access_key_id: settings[:aws_access_key_id],
-      secret_access_key: settings[:aws_secret_access_key],
+      credentials: Aws::Credentials.new(settings[:aws_access_key_id], settings[:aws_secret_access_key], settings[:aws_session_token]),
+      stub_responses: !!ENV['STUB_RESPONSES']
     )
 
     post_array = prepare_post_data(payload[:events])
-
-    post_array.each do |post_data|
-      resp = cloudwatch.put_metric_data post_data
+    begin
+      post_array.each do |post_data|
+        resp = cloudwatch.put_metric_data post_data
+      end
+    rescue Aws::SNS::Errors::AuthorizationErrorException, Aws::SNS::Errors::NotFoundException => e
+      raise Service::ConfigurationError,
+        "Error sending to Amazon CloudWatch: #{e.message}"
+    rescue Aws::Errors::ServiceError => e
+      raise Service::ConfigurationError,
+        "Error sending to Amazon CloudWatch (#{e.class.to_s.demodulize})"
     end
-
   end
 end

--- a/services/sns.rb
+++ b/services/sns.rb
@@ -12,7 +12,7 @@ class Service::SNS < Service
     )
     begin
       payload[:events].each do |event|
-        sns_client.publish(topic_arn: settings[:aws_sns_topic_arn], message: event.merge(default: syslog_format(event)).to_json)
+        sns_client.publish(topic_arn: settings[:aws_sns_topic_arn], message: syslog_format(event))
       end
     rescue Aws::SNS::Errors::AuthorizationErrorException, Aws::SNS::Errors::NotFoundException => e
       raise Service::ConfigurationError,

--- a/test/cloud_watch_test.rb
+++ b/test/cloud_watch_test.rb
@@ -1,6 +1,5 @@
 require File.expand_path('../helper.rb', __FILE__)
-require 'aws-sdk'
-
+ENV['STUB_RESPONSES'] = 'true'
 class CloudWatchTest < PapertrailServices::TestCase
 
   def setup
@@ -8,6 +7,7 @@ class CloudWatchTest < PapertrailServices::TestCase
                          aws_secret_access_key: '456',
                          metric_namespace: "papertrail-test",
                          metric_name: "test-metric",
+                         aws_region: "us-east-1"
                        }
     new_payload = payload # payload has some magic and can't be modified
     new_payload[:events].each do |e|
@@ -27,7 +27,6 @@ class CloudWatchTest < PapertrailServices::TestCase
   end
 
   def test_logs
-    AWS.stub!
     @svc.receive_logs
   end
 

--- a/test/sns_test.rb
+++ b/test/sns_test.rb
@@ -1,12 +1,10 @@
 require File.expand_path('../helper', __FILE__)
-
+ENV['STUB_RESPONSES'] = 'true'
 class SNSTest < PapertrailServices::TestCase
-  def setup
-    AWS.stub!
-  end
-
   def test_logs
-    svc = service(:logs, { :aws_access_key_id => '1', :aws_secret_access_key => '2', :aws_region => '3', :aws_sns_topic_arn => 'arn:aws:sns:us-west-1:111111111111:pagerduty-test' }, payload)
+    svc = service(:logs, { :aws_access_key_id => '1', :aws_secret_access_key => '2', :aws_region => 'us-east-1', :aws_sns_topic_arn => 'arn:aws:sns:us-east-1:111111111111:pagerduty-test' }, payload)
+    # svc.init_sns_client
+    # svc.sns_client.stub_data(:publish, {})
     svc.receive_logs
   end
 


### PR DESCRIPTION
upgrade to aws sdk v3
1. upgrade sns service to use sdk v3
2. upgrade cloudwatch service to use sdk v3
3. update tests for both services
4. test sns and cloud watch and compare to v1 implementation on real aws common env us-east-2 region.