### PR TITLE
Rescue AWS errors without logging to Sentry

### DIFF
--- a/services/cloud_watch.rb
+++ b/services/cloud_watch.rb
@@ -58,7 +58,7 @@ class Service::CloudWatch < Service
            AWS::CloudWatch::Errors::InvalidClientTokenId => e
 
       raise Service::ConfigurationError,
-        "Error sending to Amazon Cloudwatch: #{e.message}"
+        "Error sending to Amazon CloudWatch: #{e.message}"
     end
 
   end

--- a/services/cloud_watch.rb
+++ b/services/cloud_watch.rb
@@ -50,8 +50,15 @@ class Service::CloudWatch < Service
 
     post_array = prepare_post_data(payload[:events])
 
-    post_array.each do |post_data|
-      resp = cloudwatch.put_metric_data post_data
+    begin
+      post_array.each do |post_data|
+        resp = cloudwatch.put_metric_data post_data
+      end
+    rescue AWS::CloudWatch::Errors::AccessDenied,
+           AWS::CloudWatch::Errors::InvalidClientTokenId => e
+
+      raise Service::ConfigurationError,
+        "Error sending to Amazon Cloudwatch: #{e.message}"
     end
 
   end

--- a/services/sns.rb
+++ b/services/sns.rb
@@ -18,7 +18,10 @@ class Service::SNS < Service
           :default => syslog_format(event)
         }))
       end
-    rescue AWS::SNS::Errors::AuthorizationError, AWS::SNS::Errors::NotFound => e
+    rescue AWS::SNS::Errors::AuthorizationError,
+           AWS::SNS::Errors::InvalidClientTokenId,
+           AWS::SNS::Errors::NotFound => e
+
       raise Service::ConfigurationError,
         "Error sending to Amazon SNS: #{e.message}"
     rescue AWS::SNS::Errors::ServiceError => e

--- a/test/cloud_watch_test.rb
+++ b/test/cloud_watch_test.rb
@@ -11,7 +11,7 @@ class CloudWatchTest < PapertrailServices::TestCase
                        }
     new_payload = payload # payload has some magic and can't be modified
     new_payload[:events].each do |e|
-      # Cloudwatch demands recent dates
+      # CloudWatch demands recent dates
       e[:received_at] = (Time.now - rand(0..100)).iso8601
     end
 


### PR DESCRIPTION
Prevent these three AWS errors from filling up our Sentry quota.